### PR TITLE
fixed header delimiter

### DIFF
--- a/lib/serum/init.ex
+++ b/lib/serum/init.ex
@@ -83,9 +83,9 @@ defmodule Serum.Init do
   @spec init_index(ok_result) :: ok_result
   defp init_index({:ok, dir}) do
     fwrite "#{dir}pages/index.md", """
-    ===
+    ---
     title: Welcome
-    ===
+    ---
 
     *Hello, world!*
     """


### PR DESCRIPTION
was fixed in lib/serum/header_parser.ex, but not in lib/serum/init.ex