### PR TITLE
remove system dependent feature

### DIFF
--- a/lib/serum/dev_server.ex
+++ b/lib/serum/dev_server.ex
@@ -16,7 +16,10 @@ defmodule Serum.DevServer do
     import Supervisor.Spec
 
     uniq = Base.url_encode64(:crypto.strong_rand_bytes(6))
-    site = "/tmp/serum_" <> uniq
+
+    site =
+      "serum_" <> uniq
+      |> Path.expand(System.tmp_dir!())
 
     case ProjectLoader.load(dir, site) do
       {:error, _} = error ->

--- a/lib/serum/dev_server.ex
+++ b/lib/serum/dev_server.ex
@@ -17,9 +17,7 @@ defmodule Serum.DevServer do
 
     uniq = Base.url_encode64(:crypto.strong_rand_bytes(6))
 
-    site =
-      "serum_" <> uniq
-      |> Path.expand(System.tmp_dir!())
+    site = Path.expand("serum_" <> uniq, System.tmp_dir!())
 
     case ProjectLoader.load(dir, site) do
       {:error, _} = error ->

--- a/lib/serum/dev_server/service.ex
+++ b/lib/serum/dev_server/service.ex
@@ -28,7 +28,7 @@ defmodule Serum.DevServer.Service do
   @spec source_dir() :: binary
   def source_dir, do: GenServer.call(__MODULE__, :source_dir)
 
-  @doc "Returns the output directory (under `/tmp`)."
+  @doc "Returns the output directory (under temporary directory)."
   @spec site_dir() :: binary
   def site_dir, do: GenServer.call(__MODULE__, :site_dir)
 


### PR DESCRIPTION
There was a system-dependent problem when performing 'mix serum.server' on windows.

<a href="https://imgur.com/tb1wUPl"><img src="https://i.imgur.com/tb1wUPl.jpg" title="source: imgur.com" /></a>

So, I used the API below to make it work normally in Windows as well.
(https://hexdocs.pm/elixir/System.html#tmp_dir/0)