### PR TITLE
Do not generate empty Posts

### DIFF
--- a/lib/serum/build/file_processor.ex
+++ b/lib/serum/build/file_processor.ex
@@ -169,7 +169,7 @@ defmodule Serum.Build.FileProcessor do
   @spec generate_lists([map()], Project.t()) :: Result.t({[PostList.t()], tag_counts()})
   def generate_lists(compact_posts, proj)
 
-  def generate_lists([], _proj), do: {:ok, []}
+  def generate_lists([], _proj), do: {:ok, {[], []}}
 
   def generate_lists(compact_posts, proj) do
     IO.puts("Generating post lists...")

--- a/lib/serum/build/file_processor.ex
+++ b/lib/serum/build/file_processor.ex
@@ -114,13 +114,11 @@ defmodule Serum.Build.FileProcessor do
   end
 
   @doc false
-  @spec process_posts([], Project.t()) :: Result.t({[Post.t()], [map()]})
-  def process_posts([], _proj) do
-    {:ok, {[], []}}
-  end
-
-  @doc false
   @spec process_posts([Serum.File.t()], Project.t()) :: Result.t({[Post.t()], [map()]})
+  def process_posts(files, proj)
+
+  def process_posts([], _proj), do: {:ok, {[], []}}
+
   def process_posts(files, proj) do
     IO.puts("Processing post files...")
 
@@ -168,13 +166,11 @@ defmodule Serum.Build.FileProcessor do
   end
 
   @doc false
-  @spec generate_lists([], Project.t()) :: Result.t({[PostList.t()], tag_counts()})
-  def generate_lists([], _proj) do
-    {:ok, []}
-  end
-
-  @doc false
   @spec generate_lists([map()], Project.t()) :: Result.t({[PostList.t()], tag_counts()})
+  def generate_lists(compact_posts, proj)
+
+  def generate_lists([], _proj), do: {:ok, []}
+
   def generate_lists(compact_posts, proj) do
     IO.puts("Generating post lists...")
 

--- a/lib/serum/build/file_processor.ex
+++ b/lib/serum/build/file_processor.ex
@@ -114,6 +114,12 @@ defmodule Serum.Build.FileProcessor do
   end
 
   @doc false
+  @spec process_posts([], Project.t()) :: Result.t({[Post.t()], [map()]})
+  def process_posts([], _proj) do
+    {:ok, {[], []}}
+  end
+
+  @doc false
   @spec process_posts([Serum.File.t()], Project.t()) :: Result.t({[Post.t()], [map()]})
   def process_posts(files, proj) do
     IO.puts("Processing post files...")
@@ -159,6 +165,12 @@ defmodule Serum.Build.FileProcessor do
       {:invalid, message} -> {:error, {message, file.src, 0}}
       {:error, _} = plugin_error -> plugin_error
     end
+  end
+
+  @doc false
+  @spec generate_lists([], Project.t()) :: Result.t({[PostList.t()], tag_counts()})
+  def generate_lists([], _proj) do
+    {:ok, []}
   end
 
   @doc false


### PR DESCRIPTION
add new pattern for proccess_posts and generate_lists, which returns
empty lists, and so skip processing of Posts if the directory is empty

This pull request should fix #40 