### PR TITLE
v2: Show failing source codes in errors

### DIFF
--- a/lib/serum/error.ex
+++ b/lib/serum/error.ex
@@ -32,9 +32,16 @@ defmodule Serum.Error do
   end
 
   defimpl Format do
+    @type line :: {binary(), integer()}
+
     def format_text(error, indent) do
-      file_text = format_file_text(error.file, error.line)
-      head = indented([file_text, Format.format_text(error.message, 0)], indent)
+      contents = [
+        format_file_text(error.file, error.line),
+        Format.format_text(error.message, 0),
+        format_source_lines(error.file, error.line)
+      ]
+
+      head = indented(contents, indent)
       children = Enum.map(error.caused_by, &Format.format_text(&1, indent + 1))
 
       Enum.intersperse([head | children], ?\n)
@@ -49,6 +56,72 @@ defmodule Serum.Error do
         "" -> ""
         str when is_binary(str) -> [str, ?\s]
       end
+    end
+
+    @spec format_source_lines(Serum.File.t(), integer() | nil) :: IO.ANSI.ansidata()
+    defp format_source_lines(file, line)
+    defp format_source_lines(nil, _line), do: ""
+    defp format_source_lines(%Serum.File{src: nil}, _line), do: ""
+    defp format_source_lines(%Serum.File{in_data: nil}, _line), do: ""
+    defp format_source_lines(_file, nil), do: ""
+    defp format_source_lines(_file, line) when line < 1, do: ""
+
+    defp format_source_lines(%Serum.File{in_data: in_data}, line) do
+      {prev, current, next} = extract_lines(in_data, line)
+
+      gutter_width =
+        [current | next]
+        |> Enum.map(&elem(&1, 1))
+        |> Enum.max()
+        |> to_string()
+        |> String.length()
+
+      [
+        ?\n,
+        format_other_lines(prev, gutter_width),
+        format_current_line(current, gutter_width),
+        format_other_lines(next, gutter_width)
+      ]
+    end
+
+    @spec extract_lines(binary(), integer()) :: {[line()], line(), [line()]}
+    defp extract_lines(data, line) do
+      {:ok, string_io} = StringIO.open(data)
+      stream = IO.stream(string_io, :line)
+
+      [current | prev] =
+        stream
+        |> Stream.with_index(1)
+        |> Stream.take(line)
+        |> Enum.reverse()
+        |> Enum.take(4)
+
+      next = stream |> Stream.with_index(line + 1) |> Enum.take(3)
+      {:ok, _} = StringIO.close(string_io)
+
+      {Enum.reverse(prev), current, next}
+    end
+
+    @spec format_current_line(line(), integer()) :: IO.ANSI.ansidata()
+    defp format_current_line({str, line}, gutter_width) do
+      [
+        [:bright, :yellow],
+        String.pad_leading(to_string(line), gutter_width),
+        [:normal, :light_black, " | ", :bright, :yellow],
+        [str, :reset]
+      ]
+    end
+
+    @spec format_other_lines([line()], integer()) :: IO.ANSI.ansidata()
+    defp format_other_lines(lines, gutter_width) do
+      Enum.map(lines, fn {str, line} ->
+        [
+          :light_black,
+          String.pad_leading(to_string(line), gutter_width),
+          [" | ", :reset],
+          [str, :reset]
+        ]
+      end)
     end
 
     @spec indented(IO.ANSI.ansidata(), non_neg_integer()) :: IO.ANSI.ansidata()

--- a/lib/serum/error/cycle_message.ex
+++ b/lib/serum/error/cycle_message.ex
@@ -19,19 +19,19 @@ defmodule Serum.Error.CycleMessage do
       [
         "cycle detected while expanding includes:\n",
         make_graph(cycle),
-        "  Cycles are not allowed when recursively including templates.\n",
-        "  Please refactor your templates to break the cycle.\n",
-        "  Alternatively, you can use the render/1,2 template helper.\n"
+        "Cycles are not allowed when recursively including templates.\n",
+        "Please refactor your templates to break the cycle.\n",
+        "Alternatively, you can use the render/1,2 template helper.\n"
       ]
     end
 
     endl = [:reset, ?\n]
-    top = ["    ", :red, "\u256d\u2500\u2500\u2500\u2500\u2500\u256e", endl]
-    arrow = ["    ", :red, "\u2502     \u2193", endl]
-    first_text = ["    ", :red, "\u2502    ", :yellow]
-    rest_text = ["    ", :red, "\u2502    "]
-    bottom1 = ["    ", :red, "\u2502     \u2502", endl]
-    bottom2 = ["    ", :red, "\u2570\u2500\u2500\u2500\u2500\u2500\u256f", endl]
+    top = ["  ", :red, "\u256d\u2500\u2500\u2500\u2500\u2500\u256e", endl]
+    arrow = ["  ", :red, "\u2502     \u2193", endl]
+    first_text = ["  ", :red, "\u2502    ", :yellow]
+    rest_text = ["  ", :red, "\u2502    "]
+    bottom1 = ["  ", :red, "\u2502     \u2502", endl]
+    bottom2 = ["  ", :red, "\u2570\u2500\u2500\u2500\u2500\u2500\u256f", endl]
 
     @spec make_graph([String.Chars.t()]) :: IO.ANSI.ansidata()
     defp make_graph([first | rest]) do

--- a/lib/serum/header_parser.ex
+++ b/lib/serum/header_parser.ex
@@ -90,7 +90,7 @@ defmodule Serum.HeaderParser do
     |> MapSet.to_list()
     |> case do
       [] -> Result.return()
-      missings -> Result.fail(Simple, [missing_message(missings)], line: line)
+      missings -> Result.fail(Simple, [missing_message(missings)], line: line - 1)
     end
   end
 

--- a/lib/serum/header_parser/extract.ex
+++ b/lib/serum/header_parser/extract.ex
@@ -30,7 +30,7 @@ defmodule Serum.HeaderParser.Extract do
     case String.split(data, ~r/\r?\n/, parts: 2) do
       ["---", rest] -> do_extract_header(rest, acc, line + 1, true)
       [_str, rest] -> do_extract_header(rest, acc, line + 1, false)
-      [_] -> Result.fail(Simple, ["header not found"], line: line)
+      [_] -> Result.fail(Simple, ["header not found"], line: line - 1)
     end
   end
 
@@ -38,7 +38,7 @@ defmodule Serum.HeaderParser.Extract do
     case String.split(data, ~r/\r?\n/, parts: 2) do
       ["---", rest] -> Result.return({acc, rest, line + 1})
       [str, rest] -> do_extract_header(rest, [{str, line} | acc], line + 1, true)
-      [_] -> Result.fail(Simple, ["reached unexpected end of file"], line: line)
+      [_] -> Result.fail(Simple, ["reached unexpected end of file"], line: line - 1)
     end
   end
 

--- a/test/serum/header_parser/extract_test.exs
+++ b/test/serum/header_parser/extract_test.exs
@@ -31,17 +31,17 @@ defmodule Serum.HeaderParser.ExtractTest do
       Dolor
       """
 
-      assert {:error, %Error{line: 4}} = Extract.extract_header(data)
+      assert {:error, %Error{line: 3}} = Extract.extract_header(data)
     end
 
     test "returns an error if header is not properly closed" do
       data = """
-      ===
+      ---
       title: Hello, world!
       tags: foo, bar
       """
 
-      assert {:error, %Error{line: 4}} = Extract.extract_header(data)
+      assert {:error, %Error{line: 3}} = Extract.extract_header(data)
     end
   end
 end


### PR DESCRIPTION
This PR makes the implementation of `Serum.Error.Format` protocol for `Serum.Error` structs show pretty-formatted lines of failing codes, if the error struct contains valid file and line information.

Note that the displayed information may be inaccurate if the input data was manipulated by plugins.

## Examples

![2019-12-29-220546_521x229_scrot](https://user-images.githubusercontent.com/2667858/71557302-ba228f00-2a87-11ea-9d78-477908384726.png)

![2019-12-29-220626_421x131_scrot](https://user-images.githubusercontent.com/2667858/71557304-c0187000-2a87-11ea-9a0b-a6c5d4476c30.png)

![2019-12-29-220740_513x245_scrot](https://user-images.githubusercontent.com/2667858/71557305-c0b10680-2a87-11ea-8e3e-9cb223badf6f.png)
