### PR TITLE
Add open command to prompt

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -2,3 +2,4 @@
 use Mix.Config
 
 config :serum, service: Serum.DevServer.Service.Mock
+config :serum, command_handler: Serum.DevServer.CommandHandler.Mock

--- a/lib/serum/dev_server/command_handler.ex
+++ b/lib/serum/dev_server/command_handler.ex
@@ -1,0 +1,10 @@
+defmodule Serum.DevServer.CommandHandler do
+  @moduledoc false
+
+  _moduledocp = """
+  Run some commands.
+  """
+
+  @doc "Open the url in a browser."
+  @callback open_url(url :: binary()) :: {:ok | :error}
+end

--- a/lib/serum/dev_server/command_handler.ex
+++ b/lib/serum/dev_server/command_handler.ex
@@ -6,5 +6,5 @@ defmodule Serum.DevServer.CommandHandler do
   """
 
   @doc "Open the url in a browser."
-  @callback open_url(url :: binary()) :: {:ok | :error}
+  @callback open_url(url :: binary()) :: :ok | :error
 end

--- a/lib/serum/dev_server/command_handler/impl.ex
+++ b/lib/serum/dev_server/command_handler/impl.ex
@@ -12,11 +12,11 @@ defmodule Serum.DevServer.CommandHandler.Impl do
   @impl CommandHandler
   @spec open_url(url :: binary()) :: :ok | :error
   def open_url(url) do
-    open_command =
+    {open_command, args} =
       case :os.type() do
-        {:unix, :darwin} -> "open"
-        {:unix, _} -> "xdg-open"
-        {:win32, _} -> "start"
+        {:unix, :darwin} -> {"open", []}
+        {:unix, _} -> {"xdg-open", []}
+        {:win32, _} -> {"rundll32", ["url.dll,FileProtocolHandler"]}
       end
 
     case System.find_executable(open_command) do
@@ -25,7 +25,7 @@ defmodule Serum.DevServer.CommandHandler.Impl do
 
       _ ->
         try do
-          System.cmd(open_command, [url])
+          System.cmd(open_command, args ++ [url])
           :ok
         rescue
           _ -> :error

--- a/lib/serum/dev_server/command_handler/impl.ex
+++ b/lib/serum/dev_server/command_handler/impl.ex
@@ -1,0 +1,35 @@
+defmodule Serum.DevServer.CommandHandler.Impl do
+  @moduledoc false
+
+  _moduledocp = """
+  A implementation of `Serum.DevServer.CommandHandler` behaviour.
+  """
+
+  alias Serum.DevServer.CommandHandler
+
+  @behaviour CommandHandler
+
+  @impl CommandHandler
+  @spec open_url(url :: binary()) :: {:ok | :error}
+  def open_url(url) do
+    open_command =
+      case :os.type() do
+        {:unix, :darwin} -> "open"
+        {:unix, _} -> "xdg-open"
+        {:win32, _} -> "start"
+      end
+
+    case System.find_executable(open_command) do
+      nil ->
+        :error
+
+      _ ->
+        try do
+          System.cmd(open_command, [url])
+          :ok
+        rescue
+          _ -> :error
+        end
+    end
+  end
+end

--- a/lib/serum/dev_server/command_handler/impl.ex
+++ b/lib/serum/dev_server/command_handler/impl.ex
@@ -2,7 +2,7 @@ defmodule Serum.DevServer.CommandHandler.Impl do
   @moduledoc false
 
   _moduledocp = """
-  A implementation of `Serum.DevServer.CommandHandler` behaviour.
+  An implementation of `Serum.DevServer.CommandHandler` behaviour.
   """
 
   alias Serum.DevServer.CommandHandler

--- a/lib/serum/dev_server/command_handler/impl.ex
+++ b/lib/serum/dev_server/command_handler/impl.ex
@@ -10,7 +10,7 @@ defmodule Serum.DevServer.CommandHandler.Impl do
   @behaviour CommandHandler
 
   @impl CommandHandler
-  @spec open_url(url :: binary()) :: {:ok | :error}
+  @spec open_url(url :: binary()) :: :ok | :error
   def open_url(url) do
     open_command =
       case :os.type() do

--- a/lib/serum/dev_server/prompt.ex
+++ b/lib/serum/dev_server/prompt.ex
@@ -5,11 +5,13 @@ defmodule Serum.DevServer.Prompt do
 
   import Serum.IOProxy, only: [put_err: 2]
   alias Serum.DevServer.Service
+  alias Serum.DevServer.CommandHandler
 
   @type options :: [allow_detach: boolean()]
   @type result :: {:ok, :detached} | {:ok, :quitted} | {:error, :noproc}
 
   @service Application.get_env(:serum, :service, Service.GenServer)
+  @command_handler Application.get_env(:serum, :command_handler, CommandHandler.Impl)
 
   @doc """
   Tries to start a Serum development server command line interface.
@@ -65,6 +67,7 @@ defmodule Serum.DevServer.Prompt do
     Available commands are:
       help   Displays this help message
       build  Rebuilds the project
+      open   Open the site in a browser
       quit   Stops the server and quit
     """
     |> IO.write()
@@ -79,6 +82,7 @@ defmodule Serum.DevServer.Prompt do
       build   Rebuilds the project
       detach  Detaches from this command line interface
               while keeping the Serum development server running
+      open    Open the site in a browser
       quit    Stops the server and quit
     """
     |> IO.write()
@@ -103,6 +107,13 @@ defmodule Serum.DevServer.Prompt do
 
   defp do_run_command("detach", %{allow_detach: true}) do
     :detach
+  end
+
+  defp do_run_command("open", _options) do
+    case @command_handler.open_url("http://localhost:#{@service.port()}") do
+      :ok -> :ok
+      _ -> put_err(:warn, "Can't open browser")
+    end
   end
 
   defp do_run_command("quit", _options) do

--- a/lib/serum/dev_server/prompt.ex
+++ b/lib/serum/dev_server/prompt.ex
@@ -112,7 +112,7 @@ defmodule Serum.DevServer.Prompt do
   defp do_run_command("open", _options) do
     case @command_handler.open_url("http://localhost:#{@service.port()}") do
       :ok -> :ok
-      _ -> put_err(:warn, "Can't open browser")
+      _ -> put_err(:warn, "Can't open a browser")
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -19,7 +19,7 @@ defmodule Serum.Mixfile do
   end
 
   def application do
-    [applications: [:logger, :eex, :cowboy, :tzdata], mod: {Serum, []}]
+    [extra_applications: [:logger, :eex, :cowboy, :tzdata], mod: {Serum, []}]
   end
 
   defp preferred_cli_env do

--- a/mix.exs
+++ b/mix.exs
@@ -42,7 +42,8 @@ defmodule Serum.Mixfile do
       {:dialyxir, "~> 0.5", only: [:dev, :test]},
       {:floki, "~> 0.20"},
       {:ex_doc, "~> 0.20", only: :dev, runtime: false},
-      {:mix_test_watch, "~> 1.0", only: :dev, runtime: false}
+      {:mix_test_watch, "~> 1.0", only: :dev, runtime: false},
+      {:mox, "~> 0.5", only: :test}
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -14,7 +14,8 @@ defmodule Serum.Mixfile do
       preferred_cli_env: preferred_cli_env(),
       deps: deps(),
       package: package(),
-      docs: docs()
+      docs: docs(),
+      elixirc_paths: elixirc_paths(Mix.env())
     ]
   end
 
@@ -100,4 +101,7 @@ defmodule Serum.Mixfile do
       ]
     ]
   end
+
+  defp elixirc_paths(:test), do: ["test/support", "lib"]
+  defp elixirc_paths(_), do: ["lib"]
 end

--- a/mix.lock
+++ b/mix.lock
@@ -27,6 +27,7 @@
   "mimerl": {:hex, :mimerl, "1.2.0", "67e2d3f571088d5cfd3e550c383094b47159f3eee8ffa08e64106cdf5e981be3", [:rebar3], [], "hexpm"},
   "mix_test_watch": {:hex, :mix_test_watch, "1.0.1", "ae6fc45bbc80b826046fb84208df4b06035e10fae6d44d0cb48c5a2f92ee2e1d", [:mix], [{:file_system, "~> 0.2.1 or ~> 0.3", [hex: :file_system, repo: "hexpm", optional: false]}], "hexpm"},
   "mochiweb": {:hex, :mochiweb, "2.18.0", "eb55f1db3e6e960fac4e6db4e2db9ec3602cc9f30b86cd1481d56545c3145d2e", [:rebar3], [], "hexpm"},
+  "mox": {:hex, :mox, "0.5.1", "f86bb36026aac1e6f924a4b6d024b05e9adbed5c63e8daa069bd66fb3292165b", [:mix], [], "hexpm"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.1", "c90796ecee0289dbb5ad16d3ad06f957b0cd1199769641c961cfe0b97db190e0", [], [], "hexpm"},
   "parse_trans": {:hex, :parse_trans, "3.3.0", "09765507a3c7590a784615cfd421d101aec25098d50b89d7aa1d66646bc571c1", [:rebar3], [], "hexpm"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},

--- a/test/serum/dev_server/prompt_test.exs
+++ b/test/serum/dev_server/prompt_test.exs
@@ -1,12 +1,13 @@
 defmodule Serum.DevServer.PromptTest do
   use ExUnit.Case
   import ExUnit.CaptureIO
+  import Mox
   import Serum.DevServer.Prompt
   import Serum.TestHelper
   alias Serum.DevServer.Service
   alias Serum.IOProxy
 
-  @commands ~w(build help quit)
+  @commands ~w(build help open quit)
 
   setup_all do
     {:ok, io_opts} = IOProxy.config()
@@ -99,6 +100,19 @@ defmodule Serum.DevServer.PromptTest do
         end)
 
       refute "" === String.trim(stderr)
+    end
+
+    test "handles 'open' command" do
+      Serum.DevServer.CommandHandler.Mock
+      |> expect(:open_url, fn "http://localhost:8080" -> :ok end)
+
+      stderr =
+        capture_io(:stderr, fn ->
+          send(self(), run_command("open", %{}))
+        end)
+
+      assert String.trim(stderr) === ""
+      assert_received :ok
     end
 
     test "handles 'quit' command", %{site: site} do

--- a/test/serum/dev_server/prompt_test.exs
+++ b/test/serum/dev_server/prompt_test.exs
@@ -115,6 +115,19 @@ defmodule Serum.DevServer.PromptTest do
       assert_received :ok
     end
 
+    test "prints a warning when failed to open a browser" do
+      Serum.DevServer.CommandHandler.Mock
+      |> expect(:open_url, fn "http://localhost:8080" -> :error end)
+
+      stderr =
+        capture_io(:stderr, fn ->
+          send(self(), run_command("open", %{}))
+        end)
+
+      assert stderr =~ "Can't open a browser"
+      assert_received :ok
+    end
+
     test "handles 'quit' command", %{site: site} do
       assert File.exists?(site)
 

--- a/test/support/mocks.ex
+++ b/test/support/mocks.ex
@@ -1,0 +1,1 @@
+Mox.defmock(Serum.DevServer.CommandHandler.Mock, for: Serum.DevServer.CommandHandler)


### PR DESCRIPTION
This PR add `open` command to prompt.
It opens the site in a browser.

## Examples

![image](https://user-images.githubusercontent.com/4961183/71641273-4200d700-2cdc-11ea-924c-2bbb9c09bc73.png)
