### PR TITLE
feat(v1): add support for custom blog paths

### DIFF
--- a/lib/serum/build.ex
+++ b/lib/serum/build.ex
@@ -87,7 +87,7 @@ defmodule Serum.Build do
 
   @spec do_build(Project.t()) :: Result.t()
   defp do_build(%{src: src, dest: dest} = proj) do
-    with {:ok, files} <- FileLoader.load_files(src),
+    with {:ok, files} <- FileLoader.load_files(proj),
          {:ok, map} <- FileProcessor.process_files(files, proj),
          {:ok, fragments} <- FragmentGenerator.to_fragment(map),
          {:ok, files} <- PageGenerator.run(fragments),

--- a/lib/serum/build/file_loader.ex
+++ b/lib/serum/build/file_loader.ex
@@ -4,6 +4,7 @@ defmodule Serum.Build.FileLoader do
   _moduledocp = "A module responsible for loading project files."
 
   alias Serum.Build.FileLoader.{Includes, Pages, Posts, Templates}
+  alias Serum.Project
   alias Serum.Result
 
   @type result :: %{
@@ -27,12 +28,12 @@ defmodule Serum.Build.FileLoader do
   this function won't fail even if they don't exist. The corresponding lists
   in the resulting map will be empty.
   """
-  @spec load_files(binary()) :: Result.t(result())
-  def load_files(src) do
+  @spec load_files(Project.t()) :: Result.t(result())
+  def load_files(%Project{src: src, posts_path: posts_path}) do
     with {:ok, template_files} <- Templates.load(src),
          {:ok, include_files} <- Includes.load(src),
          {:ok, page_files} <- Pages.load(src),
-         {:ok, post_files} <- Posts.load(src) do
+         {:ok, post_files} <- Posts.load(src, posts_path) do
       {:ok,
        %{
          templates: template_files,

--- a/lib/serum/build/file_loader.ex
+++ b/lib/serum/build/file_loader.ex
@@ -29,11 +29,11 @@ defmodule Serum.Build.FileLoader do
   in the resulting map will be empty.
   """
   @spec load_files(Project.t()) :: Result.t(result())
-  def load_files(%Project{src: src, posts_path: posts_path}) do
+  def load_files(%Project{src: src, posts_source: posts_source}) do
     with {:ok, template_files} <- Templates.load(src),
          {:ok, include_files} <- Includes.load(src),
          {:ok, page_files} <- Pages.load(src),
-         {:ok, post_files} <- Posts.load(src, posts_path) do
+         {:ok, post_files} <- Posts.load(src, posts_source) do
       {:ok,
        %{
          templates: template_files,

--- a/lib/serum/build/file_loader/posts.ex
+++ b/lib/serum/build/file_loader/posts.ex
@@ -10,10 +10,10 @@ defmodule Serum.Build.FileLoader.Posts do
 
   @doc false
   @spec load(binary(), binary()) :: Result.t([Serum.File.t()])
-  def load(src, posts_path) do
+  def load(src, posts_source) do
     put_msg(:info, "Loading post files...")
 
-    posts_dir = get_subdir(src, posts_path)
+    posts_dir = get_subdir(src, posts_source)
 
     if File.exists?(posts_dir) do
       posts_dir

--- a/lib/serum/build/file_loader/posts.ex
+++ b/lib/serum/build/file_loader/posts.ex
@@ -9,11 +9,11 @@ defmodule Serum.Build.FileLoader.Posts do
   alias Serum.Result
 
   @doc false
-  @spec load(binary()) :: Result.t([Serum.File.t()])
-  def load(src) do
+  @spec load(binary(), binary()) :: Result.t([Serum.File.t()])
+  def load(src, posts_path) do
     put_msg(:info, "Loading post files...")
 
-    posts_dir = get_subdir(src, "posts")
+    posts_dir = get_subdir(src, posts_path)
 
     if File.exists?(posts_dir) do
       posts_dir
@@ -26,7 +26,7 @@ defmodule Serum.Build.FileLoader.Posts do
         {:error, _} = plugin_error -> plugin_error
       end
     else
-      put_err(:warn, "Cannot access `posts/'. No post will be generated.")
+      put_err(:warn, "Cannot access the posts directory. Your blog will not be generated.")
 
       {:ok, []}
     end

--- a/lib/serum/post.ex
+++ b/lib/serum/post.ex
@@ -69,8 +69,8 @@ defmodule Serum.Post do
       preview: preview,
       raw_date: raw_date,
       date: date_str,
-      url: Path.join([proj.base_url, proj.posts_url, output_name]),
-      output: Path.join([proj.dest, proj.posts_url, output_name]),
+      url: Path.join([proj.base_url, proj.posts_path, output_name]),
+      output: Path.join([proj.dest, proj.posts_path, output_name]),
       template: header[:template],
       extras: extras
     }

--- a/lib/serum/post.ex
+++ b/lib/serum/post.ex
@@ -17,6 +17,7 @@ defmodule Serum.Post do
 
   alias Serum.Fragment
   alias Serum.Post.PreviewGenerator
+  alias Serum.Project
   alias Serum.Renderer
   alias Serum.Result
   alias Serum.Tag
@@ -51,18 +52,14 @@ defmodule Serum.Post do
     :template
   ]
 
-  @spec new(binary(), {map(), map()}, binary(), map()) :: t()
-  def new(path, {header, extras}, html, proj) do
+  @spec new(binary(), {map(), map()}, binary(), Project.t()) :: t()
+  def new(path, {header, extras}, html, %Project{} = proj) do
     tags = Tag.batch_create(header[:tags] || [], proj)
     datetime = header[:date]
     date_str = Timex.format!(datetime, proj.date_format)
     raw_date = to_erl_datetime(datetime)
     preview = PreviewGenerator.generate_preview(html, proj.preview_length)
-
-    filename =
-      path
-      |> String.replace_suffix("md", "html")
-      |> Path.relative_to(proj.src)
+    output_name = Path.basename(path, ".md") <> ".html"
 
     %__MODULE__{
       file: path,
@@ -72,8 +69,8 @@ defmodule Serum.Post do
       preview: preview,
       raw_date: raw_date,
       date: date_str,
-      url: Path.join(proj.base_url, filename),
-      output: Path.join(proj.dest, filename),
+      url: Path.join([proj.base_url, proj.posts_url, output_name]),
+      output: Path.join([proj.dest, proj.posts_url, output_name]),
       template: header[:template],
       extras: extras
     }

--- a/lib/serum/post_list.ex
+++ b/lib/serum/post_list.ex
@@ -64,7 +64,7 @@ defmodule Serum.PostList do
       |> Enum.with_index(1)
 
     max_page = length(paginated_posts)
-    list_dir = (tag && Path.join(proj.tags_url, tag.name)) || proj.posts_url
+    list_dir = (tag && Path.join(proj.tags_path, tag.name)) || proj.posts_path
 
     lists =
       Enum.map(paginated_posts, fn {posts, page} ->

--- a/lib/serum/post_list.ex
+++ b/lib/serum/post_list.ex
@@ -19,6 +19,7 @@ defmodule Serum.PostList do
 
   alias Serum.Fragment
   alias Serum.Plugin
+  alias Serum.Project
   alias Serum.Renderer
   alias Serum.Result
   alias Serum.Tag
@@ -52,8 +53,8 @@ defmodule Serum.PostList do
     :extras
   ]
 
-  @spec generate(maybe_tag(), [map()], map()) :: Result.t([t()])
-  def generate(tag, posts, proj) do
+  @spec generate(maybe_tag(), [map()], Project.t()) :: Result.t([t()])
+  def generate(tag, posts, %Project{} = proj) do
     paginate? = proj.pagination
     num_posts = proj.posts_per_page
 
@@ -63,7 +64,7 @@ defmodule Serum.PostList do
       |> Enum.with_index(1)
 
     max_page = length(paginated_posts)
-    list_dir = (tag && Path.join("tags", tag.name)) || "posts"
+    list_dir = (tag && Path.join(proj.tags_url, tag.name)) || proj.posts_url
 
     lists =
       Enum.map(paginated_posts, fn {posts, page} ->
@@ -124,7 +125,7 @@ defmodule Serum.PostList do
     Enum.chunk_every(posts, num_posts)
   end
 
-  @spec list_title(maybe_tag(), map()) :: binary()
+  @spec list_title(maybe_tag(), Project.t()) :: binary()
   defp list_title(tag, proj)
   defp list_title(nil, proj), do: proj.list_title_all
 

--- a/lib/serum/project.ex
+++ b/lib/serum/project.ex
@@ -9,6 +9,7 @@ defmodule Serum.Project do
 
   @default_date_format "{YYYY}-{0M}-{0D}"
   @default_list_title_tag "Posts Tagged ~s"
+  @default_posts_path "posts"
 
   defstruct site_name: "",
             site_description: "",
@@ -22,6 +23,9 @@ defmodule Serum.Project do
             pagination: false,
             posts_per_page: 5,
             preview_length: 200,
+            posts_path: @default_posts_path,
+            posts_url: @default_posts_path,
+            tags_url: "tags",
             src: nil,
             dest: nil,
             plugins: [],
@@ -42,6 +46,9 @@ defmodule Serum.Project do
           pagination: boolean(),
           posts_per_page: pos_integer(),
           preview_length: non_neg_integer(),
+          posts_path: binary(),
+          posts_url: binary(),
+          tags_url: binary(),
           plugins: [Plugin.plugin_spec()],
           theme: Theme.t()
         }
@@ -52,18 +59,19 @@ defmodule Serum.Project do
   @spec default_list_title_tag() :: binary()
   def default_list_title_tag, do: @default_list_title_tag
 
-  @doc "A helper function for creating a new Project struct."
-  @spec new(map) :: t
+  @doc "Creates a new Project struct using the given `map`."
+  @spec new(map()) :: t()
   def new(map) do
     checked_map =
       map
       |> check_date_format()
       |> check_list_title_format()
+      |> set_default_posts_url()
 
     struct(__MODULE__, checked_map)
   end
 
-  @spec check_date_format(map) :: map
+  @spec check_date_format(map()) :: map()
   defp check_date_format(map) do
     case map[:date_format] do
       nil ->
@@ -87,7 +95,7 @@ defmodule Serum.Project do
     end
   end
 
-  @spec check_list_title_format(map) :: map
+  @spec check_list_title_format(map()) :: map()
   defp check_list_title_format(map) do
     case map[:list_title_tag] do
       nil ->
@@ -106,5 +114,13 @@ defmodule Serum.Project do
 
       put_err(:warn, String.trim(msg))
       Map.delete(map, :list_title_tag)
+  end
+
+  @spec set_default_posts_url(map()) :: map()
+  defp set_default_posts_url(map) do
+    case map[:posts_url] do
+      posts_url when is_binary(posts_url) -> map
+      _ -> Map.put(map, :posts_url, map[:posts_path] || @default_posts_path)
+    end
   end
 end

--- a/lib/serum/project.ex
+++ b/lib/serum/project.ex
@@ -9,7 +9,7 @@ defmodule Serum.Project do
 
   @default_date_format "{YYYY}-{0M}-{0D}"
   @default_list_title_tag "Posts Tagged ~s"
-  @default_posts_path "posts"
+  @default_posts_source "posts"
 
   defstruct site_name: "",
             site_description: "",
@@ -23,9 +23,9 @@ defmodule Serum.Project do
             pagination: false,
             posts_per_page: 5,
             preview_length: 200,
-            posts_path: @default_posts_path,
-            posts_url: @default_posts_path,
-            tags_url: "tags",
+            posts_source: @default_posts_source,
+            posts_path: @default_posts_source,
+            tags_path: "tags",
             src: nil,
             dest: nil,
             plugins: [],
@@ -46,9 +46,9 @@ defmodule Serum.Project do
           pagination: boolean(),
           posts_per_page: pos_integer(),
           preview_length: non_neg_integer(),
+          posts_source: binary(),
           posts_path: binary(),
-          posts_url: binary(),
-          tags_url: binary(),
+          tags_path: binary(),
           plugins: [Plugin.plugin_spec()],
           theme: Theme.t()
         }
@@ -66,7 +66,7 @@ defmodule Serum.Project do
       map
       |> check_date_format()
       |> check_list_title_format()
-      |> set_default_posts_url()
+      |> set_default_posts_path()
 
     struct(__MODULE__, checked_map)
   end
@@ -116,11 +116,11 @@ defmodule Serum.Project do
       Map.delete(map, :list_title_tag)
   end
 
-  @spec set_default_posts_url(map()) :: map()
-  defp set_default_posts_url(map) do
-    case map[:posts_url] do
-      posts_url when is_binary(posts_url) -> map
-      _ -> Map.put(map, :posts_url, map[:posts_path] || @default_posts_path)
+  @spec set_default_posts_path(map()) :: map()
+  defp set_default_posts_path(map) do
+    case map[:posts_path] do
+      posts_path when is_binary(posts_path) -> map
+      _ -> Map.put(map, :posts_path, map[:posts_source] || @default_posts_source)
     end
   end
 end

--- a/lib/serum/project/elixir_validator.ex
+++ b/lib/serum/project/elixir_validator.ex
@@ -18,6 +18,9 @@ defmodule Serum.Project.ElixirValidator do
     :pagination,
     :posts_per_page,
     :preview_length,
+    :posts_path,
+    :posts_url,
+    :tags_url,
     :plugins,
     :theme
   ]
@@ -128,6 +131,9 @@ defmodule Serum.Project.ElixirValidator do
         pagination: [is_boolean: []],
         posts_per_page: [is_integer: [], >=: [1]],
         preview_length: [valid_preview_length?: []],
+        posts_path: [is_binary: []],
+        posts_url: [is_binary: []],
+        tags_url: [is_binary: []],
         plugins: [is_list: []],
         theme: [is_atom: []]
       ]

--- a/lib/serum/project/elixir_validator.ex
+++ b/lib/serum/project/elixir_validator.ex
@@ -18,9 +18,9 @@ defmodule Serum.Project.ElixirValidator do
     :pagination,
     :posts_per_page,
     :preview_length,
+    :posts_source,
     :posts_path,
-    :posts_url,
-    :tags_url,
+    :tags_path,
     :plugins,
     :theme
   ]
@@ -131,9 +131,9 @@ defmodule Serum.Project.ElixirValidator do
         pagination: [is_boolean: []],
         posts_per_page: [is_integer: [], >=: [1]],
         preview_length: [valid_preview_length?: []],
+        posts_source: [is_binary: []],
         posts_path: [is_binary: []],
-        posts_url: [is_binary: []],
-        tags_url: [is_binary: []],
+        tags_path: [is_binary: []],
         plugins: [is_list: []],
         theme: [is_atom: []]
       ]

--- a/lib/serum/tag.ex
+++ b/lib/serum/tag.ex
@@ -14,7 +14,7 @@ defmodule Serum.Tag do
   def new(name, %Project{} = proj) do
     %__MODULE__{
       name: name,
-      list_url: Path.join([proj.base_url, proj.tags_url, name])
+      list_url: Path.join([proj.base_url, proj.tags_path, name])
     }
   end
 

--- a/lib/serum/tag.ex
+++ b/lib/serum/tag.ex
@@ -1,6 +1,8 @@
 defmodule Serum.Tag do
   @moduledoc "This module defines Tag struct."
 
+  alias Serum.Project
+
   @type t :: %__MODULE__{
           name: binary(),
           list_url: binary()
@@ -8,16 +10,16 @@ defmodule Serum.Tag do
 
   defstruct [:name, :list_url]
 
-  @spec new(binary(), map()) :: t()
-  def new(name, proj) do
+  @spec new(binary(), Project.t()) :: t()
+  def new(name, %Project{} = proj) do
     %__MODULE__{
       name: name,
-      list_url: Path.join([proj.base_url, "tags", name])
+      list_url: Path.join([proj.base_url, proj.tags_url, name])
     }
   end
 
-  @spec batch_create([binary()], map()) :: [t()]
-  def batch_create(names, proj) do
+  @spec batch_create([binary()], Project.t()) :: [t()]
+  def batch_create(names, %Project{} = proj) do
     names |> Enum.uniq() |> Enum.sort() |> Enum.map(&new(&1, proj))
   end
 end

--- a/test/serum/build/file_loader/posts_test.exs
+++ b/test/serum/build/file_loader/posts_test.exs
@@ -8,7 +8,7 @@ defmodule Serum.Build.FileLoader.PostsTest do
   |> fixture()
   |> Code.require_file()
 
-  describe "load/1" do
+  describe "load/2" do
     setup do
       tmp_dir = get_tmp_dir("serum_test_")
 
@@ -27,12 +27,12 @@ defmodule Serum.Build.FileLoader.PostsTest do
 
       make_files(posts_dir)
 
-      assert {:ok, posts} = load(tmp_dir)
+      assert {:ok, posts} = load(tmp_dir, "posts")
       assert 3 === length(posts)
     end
 
     test "does not fail even if the posts directory does not exist", %{tmp_dir: tmp_dir} do
-      assert {:ok, []} === load(tmp_dir)
+      assert {:ok, []} === load(tmp_dir, "non_existent_directory")
     end
 
     test "fails when some files cannot be loaded", %{tmp_dir: tmp_dir} do
@@ -42,7 +42,7 @@ defmodule Serum.Build.FileLoader.PostsTest do
       make_files(posts_dir)
       File.chmod!(foo, 0o000)
 
-      assert {:error, _} = load(tmp_dir)
+      assert {:error, _} = load(tmp_dir, "posts")
 
       File.chmod!(foo, 0o644)
     end
@@ -54,7 +54,7 @@ defmodule Serum.Build.FileLoader.PostsTest do
 
       {:ok, _} = Plugin.load_plugins([Serum.FailingPlugin1])
 
-      assert {:error, _} = load(tmp_dir)
+      assert {:error, _} = load(tmp_dir, "posts")
     end
   end
 

--- a/test/serum/build/file_loader_test.exs
+++ b/test/serum/build/file_loader_test.exs
@@ -2,6 +2,7 @@ defmodule Serum.Build.FileLoaderTest do
   use ExUnit.Case, async: true
   import Serum.TestHelper
   alias Serum.Build.FileLoader
+  alias Serum.Project
 
   setup do
     tmp_dir = get_tmp_dir("serum_test_")
@@ -31,19 +32,21 @@ defmodule Serum.Build.FileLoaderTest do
 
   describe "load_files/1" do
     test "loads four kinds of files", %{tmp_dir: tmp_dir} do
-      {:ok, %{pages: pages, posts: posts, templates: temps, includes: incls}} =
-        FileLoader.load_files(tmp_dir)
+      proj = Project.new(%{src: tmp_dir})
 
-      assert length(pages) === 1
-      assert length(posts) === 1
-      assert length(temps) === 4
-      assert length(incls) === 1
+      assert {:ok, load_result} = FileLoader.load_files(proj)
+
+      Enum.each([pages: 1, posts: 1, templates: 4, includes: 1], fn {k, v} ->
+        assert length(load_result[k]) === v
+      end)
     end
 
     test "fails when one or more sub tasks fail", %{tmp_dir: tmp_dir} do
+      proj = Project.new(%{src: tmp_dir})
+
       File.rm_rf!(Path.join(tmp_dir, "pages"))
 
-      {:error, {:enoent, _, _}} = FileLoader.load_files(tmp_dir)
+      {:error, {:enoent, _, _}} = FileLoader.load_files(proj)
     end
   end
 end

--- a/test/serum/build/file_processor/post_list_test.exs
+++ b/test/serum/build/file_processor/post_list_test.exs
@@ -1,6 +1,7 @@
 defmodule Serum.Build.FileProcessor.PostListTest do
   use ExUnit.Case, async: true
   alias Serum.Build.FileProcessor.PostList, as: ListGenerator
+  alias Serum.Project
   alias Serum.Tag
 
   setup_all do
@@ -36,7 +37,7 @@ defmodule Serum.Build.FileProcessor.PostListTest do
   describe "generate_lists/2" do
     test "no pagination", ctx do
       posts = ctx.compact_posts
-      proj = Map.put(ctx.proj_template, :pagination, false)
+      proj = Project.new(Map.put(ctx.proj_template, :pagination, false))
       {:ok, {lists, counts}} = ListGenerator.generate_lists(posts, proj)
 
       # (num_of_tags + 1) * (index + page_1)
@@ -62,7 +63,7 @@ defmodule Serum.Build.FileProcessor.PostListTest do
 
     test "chunk every 5 posts", ctx do
       posts = ctx.compact_posts
-      proj = Map.put(ctx.proj_template, :pagination, true)
+      proj = Project.new(Map.put(ctx.proj_template, :pagination, true))
       {:ok, {lists, counts}} = ListGenerator.generate_lists(posts, proj)
 
       # num_of_tags * (index + page_1_to_4) + 1 * (index + page_1_to_6)

--- a/test/serum/build/file_processor/post_test.exs
+++ b/test/serum/build/file_processor/post_test.exs
@@ -20,7 +20,8 @@ defmodule Serum.Build.FileProcessor.PostTest do
                title: "Test Post",
                date: "2019-01-01",
                raw_date: {{2019, 1, 1}, {12, 34, 56}},
-               tags: [%{name: "tag1"}, %{name: "tag2"}]
+               tags: [%{name: "tag1"}, %{name: "tag2"}],
+               output: "/path/to/dest/posts/good-post.html"
              } = post
 
       assert_compact(compact_post)
@@ -34,7 +35,8 @@ defmodule Serum.Build.FileProcessor.PostTest do
                title: "Test Post",
                date: "2019-01-01",
                raw_date: {{2019, 1, 1}, {0, 0, 0}},
-               tags: [%{name: "tag3"}, %{name: "tag4"}]
+               tags: [%{name: "tag3"}, %{name: "tag4"}],
+               output: "/path/to/dest/posts/good-alternative-date.html"
              } = post
 
       assert_compact(compact_post)
@@ -48,7 +50,8 @@ defmodule Serum.Build.FileProcessor.PostTest do
                title: "Test Post",
                date: "2019-01-01",
                raw_date: {{2019, 1, 1}, {0, 0, 0}},
-               tags: []
+               tags: [],
+               output: "/path/to/dest/posts/good-minimal-header.html"
              } = post
 
       assert_compact(compact_post)

--- a/test/serum/project/elixir_validator_test.exs
+++ b/test/serum/project/elixir_validator_test.exs
@@ -42,9 +42,9 @@ defmodule Serum.Project.ElixirValidatorTest do
           pagination: true,
           posts_per_page: 10,
           preview_length: 200,
-          posts_path: "posts",
-          posts_url: "blog",
-          tags_url: "blog/tags",
+          posts_source: "posts",
+          posts_path: "blog",
+          tags_path: "blog/tags",
           plugins: [Serum.TestPlugin1, Serum.TestPlugin2],
           theme: Serum.TestTheme
         })

--- a/test/serum/project_test.exs
+++ b/test/serum/project_test.exs
@@ -87,4 +87,35 @@ defmodule Serum.ProjecTest do
       end
     end
   end
+
+  describe "default values for post paths" do
+    test "puts default values when none of them is given" do
+      proj = Project.new(%{})
+
+      assert proj.posts_path === "posts"
+      assert proj.posts_url === "posts"
+      assert proj.tags_url === "tags"
+    end
+
+    test "uses posts_path when posts_url is not given" do
+      proj = Project.new(%{posts_path: "blog"})
+
+      assert proj.posts_path === "blog"
+      assert proj.posts_url === "blog"
+      assert proj.tags_url === "tags"
+    end
+
+    test "does not fallback if all paths are given" do
+      proj =
+        Project.new(%{
+          posts_path: "posts",
+          posts_url: "blog",
+          tags_url: "blog/tags"
+        })
+
+      assert proj.posts_path === "posts"
+      assert proj.posts_url === "blog"
+      assert proj.tags_url === "blog/tags"
+    end
+  end
 end

--- a/test/serum/project_test.exs
+++ b/test/serum/project_test.exs
@@ -92,30 +92,30 @@ defmodule Serum.ProjecTest do
     test "puts default values when none of them is given" do
       proj = Project.new(%{})
 
+      assert proj.posts_source === "posts"
       assert proj.posts_path === "posts"
-      assert proj.posts_url === "posts"
-      assert proj.tags_url === "tags"
+      assert proj.tags_path === "tags"
     end
 
-    test "uses posts_path when posts_url is not given" do
-      proj = Project.new(%{posts_path: "blog"})
+    test "uses posts_source when posts_path is not given" do
+      proj = Project.new(%{posts_source: "blog"})
 
+      assert proj.posts_source === "blog"
       assert proj.posts_path === "blog"
-      assert proj.posts_url === "blog"
-      assert proj.tags_url === "tags"
+      assert proj.tags_path === "tags"
     end
 
     test "does not fallback if all paths are given" do
       proj =
         Project.new(%{
-          posts_path: "posts",
-          posts_url: "blog",
-          tags_url: "blog/tags"
+          posts_source: "posts",
+          posts_path: "blog",
+          tags_path: "blog/tags"
         })
 
-      assert proj.posts_path === "posts"
-      assert proj.posts_url === "blog"
-      assert proj.tags_url === "blog/tags"
+      assert proj.posts_source === "posts"
+      assert proj.posts_path === "blog"
+      assert proj.tags_path === "blog/tags"
     end
   end
 end

--- a/test/serum/tag_test.exs
+++ b/test/serum/tag_test.exs
@@ -4,7 +4,7 @@ defmodule Serum.TagTest do
   alias Serum.Project
 
   test "batch creation of tags" do
-    proj = Project.new(%{base_url: "/test", tags_url: "blog/tags"})
+    proj = Project.new(%{base_url: "/test", tags_path: "blog/tags"})
     tags = batch_create(["hello", "beautiful", "world"], proj)
 
     # Note that tags should be sorted in lexicographic order.

--- a/test/serum/tag_test.exs
+++ b/test/serum/tag_test.exs
@@ -1,18 +1,19 @@
 defmodule Serum.TagTest do
   use ExUnit.Case, async: true
   import Serum.Tag
+  alias Serum.Project
 
   test "batch creation of tags" do
-    proj = %{base_url: "/test"}
-
-    # Note that tags should be lexicographically sorted.
+    proj = Project.new(%{base_url: "/test", tags_url: "blog/tags"})
     tags = batch_create(["hello", "beautiful", "world"], proj)
+
+    # Note that tags should be sorted in lexicographic order.
     expected_names = ["beautiful", "hello", "world"]
 
     expected_urls = [
-      "/test/tags/beautiful",
-      "/test/tags/hello",
-      "/test/tags/world"
+      "/test/blog/tags/beautiful",
+      "/test/blog/tags/hello",
+      "/test/blog/tags/world"
     ]
 
     [tags, expected_names, expected_urls]


### PR DESCRIPTION
Closes #136.

Adds three new keys to `serum.exs` project configuration file.

- `:posts_source` (string, optional)

  Path to a directory which holds source files for your blog posts. Defaults to `"posts"`.

- `:posts_path` (string, optional)

  Path in an output directory which your rendered blog posts will be written to. Defaults to the value of `:posts_source`.

  (Obviously, the default value will be `"posts"` if `:posts_source` is not explicitly given.)

- `:tags_path` (string, optional)

  Path in an output directory which the tag pages will be written to. Defaults to `"tags"`.

## Next Step

- Update documentation in the official website ([Dalgona/serum-site](https://github.com/Dalgona/serum-site)). <sup>[until the next release]</sup>