### PR TITLE
support code blocks via earmark & skip return code of gen_tcp

### DIFF
--- a/lib/serum/markdown.ex
+++ b/lib/serum/markdown.ex
@@ -15,7 +15,7 @@ defmodule Serum.Markdown do
   @spec to_html(binary(), Project.t()) :: binary()
   def to_html(markdown, proj) do
     markdown
-    |> Earmark.as_html!()
+    |> Earmark.as_html!(code_class_prefix: "lang-")
     |> process_links(proj.base_url)
   end
 

--- a/test/serum/dev_server_test.exs
+++ b/test/serum/dev_server_test.exs
@@ -37,7 +37,7 @@ defmodule Serum.DevServerTest do
       Process.flag(:trap_exit, true)
       Process.group_leader(self(), ctx.ignore_io)
 
-      {:ok, sock} = :gen_tcp.listen(8080, [])
+      {result, sock} = :gen_tcp.listen(8080, [])
       assert {:error, msg} = DevServer.run(ctx.tmp_dir, 8080)
       assert String.contains?(msg, "8080")
       :ok = :gen_tcp.close(sock)

--- a/test/serum/markdown_test.exs
+++ b/test/serum/markdown_test.exs
@@ -21,6 +21,13 @@ defmodule Serum.MarkdownTest do
 
   <img src="%media:images/sample.png" alt="Sample picture">
 
+  ## Prism HTML tags are applied
+  
+  ```elixir
+  defmodule Awesome do
+  end
+  ```
+
   ## These won't be processed
 
   - %page:docs/index


### PR DESCRIPTION
- gen_tcp can return an error if the port is already in use, so we need to skip it
- code blocks require a prefix `lang-` to be shown in syntax highlighting